### PR TITLE
Adding files match with paths argument into coverage list

### DIFF
--- a/lib/coverage.js
+++ b/lib/coverage.js
@@ -49,7 +49,10 @@ exports.instrument = function(options) {
     var matcher, instrumenter;
 
     matcher = function (file) {
-        return file === options.code.path;
+        return file === options.code.path || _.some(options.paths, 
+            function(p) {
+                return file.match(p.path);
+            });
     }
     instrumenter = new istanbul.Instrumenter();
     istanbul.hook.hookRequire(matcher, instrumenter.instrumentSync.bind(instrumenter));

--- a/lib/testrunner.js
+++ b/lib/testrunner.js
@@ -176,6 +176,7 @@ exports.run = function(files, callback) {
         opts.deps = absPaths(opts.deps);
         opts.code = absPath(opts.code);
         opts.tests = absPaths(opts.tests);
+        opts.paths = absPaths(opts.paths);
 
         runOne(opts, function(err, stat) {
             if (err) {


### PR DESCRIPTION
I discovered that:
- The coverage option (`--cov` or `coverage=true`) does coverage only the source file, but does not coverage other modules required by the source.
- The option `-p` or `--paths` has not been used anywhere in your code.

In this PR, I make the files that match the paths parameter include in coverage report, which I think it could be useful. Please review. 
