### PR TITLE
Default reporters lcov, json with a way to specify it from runner

### DIFF
--- a/lib/coverage.js
+++ b/lib/coverage.js
@@ -4,7 +4,8 @@ var path = require('path'),
 var istanbul,
     collector,
     options = {
-        dir: 'coverage'
+        dir: 'coverage',
+        reporters: ['lcov', 'json']
     };
 
 try {
@@ -38,7 +39,11 @@ exports.report = function() {
 
     if (collector) {
         Report = istanbul.Report;
-        reports = [Report.create('lcov', options), Report.create('json', options)];
+
+        reports = options.reporters.map(function (report) {
+            return Report.create(report, options);
+        });
+
         reports.forEach(function(rep) {
             rep.writeReport(collector, true);
         });

--- a/readme.md
+++ b/readme.md
@@ -244,4 +244,10 @@ Some tests examples
 
 ### Coverage
 
-Code coverage via Istanbul. To utilize, install `istanbul` and set option `coverage: true` or give a path where to store report `coverage: {dir: "coverage/path"}` or pass `--cov` parameter in the shell. Coverage calculations based on code and tests passed to `node-qunit`.
+Code coverage via Istanbul.
+
+To utilize, install `istanbul` and set option `coverage: true` or give a path where to store report `coverage: {dir: "coverage/path"}` or pass `--cov` parameter in the shell.
+
+To specify the format of coverage report pass reporters array to the coverage options: `coverage: {reporters: ['lcov', 'json']}` (default)
+
+Coverage calculations based on code and tests passed to `node-qunit`.


### PR DESCRIPTION
I need to generate cobertura report for jenkins
with this users can pass reporters to istanbul
```js 
coverage: {
  dir: 'dir',
  reporters: ['cobertura', 'lcov']
}
```