### PR TITLE
allow coverage instrumentation of multiple files

### DIFF
--- a/lib/coverage.js
+++ b/lib/coverage.js
@@ -54,9 +54,17 @@ exports.instrument = function(options) {
     var matcher, instrumenter;
 
     matcher = function (file) {
-        if (typeof options.coverage === 'string') return file.indexOf(options.coverage) === 0;
-        else if (options.coverage instanceof RegExp) return options.coverage.test(file);
-        else return file === options.code.path;
+        var files = options.coverage.files;
+        if (files) {
+            files = Array.isArray(files) ? files : [files];
+            return files.some(function(f) {
+                if (typeof f === 'string') return file.indexOf(f) === 0;
+                else if (f instanceof RegExp) return f.test(file);
+                else throw new Error("invalid entry in options.coverage.files: " + typeof f);
+            });
+        } else {
+            return file === options.code.path;
+        }
     }
     instrumenter = new istanbul.Instrumenter();
     istanbul.hook.hookRequire(matcher, instrumenter.instrumentSync.bind(instrumenter));

--- a/lib/coverage.js
+++ b/lib/coverage.js
@@ -54,7 +54,9 @@ exports.instrument = function(options) {
     var matcher, instrumenter;
 
     matcher = function (file) {
-        return file === options.code.path;
+        if (typeof options.coverage === 'string') return file.indexOf(options.coverage) === 0;
+        else if (options.coverage instanceof RegExp) return options.coverage.test(file);
+        else return file === options.code.path;
     }
     instrumenter = new istanbul.Instrumenter();
     istanbul.hook.hookRequire(matcher, instrumenter.instrumentSync.bind(instrumenter));


### PR DESCRIPTION
This PR is a quick hack to enable code coverage on multiple files. It allows you to set the coverage option to:

* a string, in which case all source files with an absolute path matching the string will be included in the coverage report.
* a regexp, in which case all source files with a path that matches the regexp will be included.
* true, in which case only the file specified with the `code` option will be included in the coverage report.
